### PR TITLE
Load manageable competitions from the past month

### DIFF
--- a/src/logic/wca-api.js
+++ b/src/logic/wca-api.js
@@ -1,10 +1,10 @@
 import { WCA_ORIGIN } from './wca-env';
 
 export const getUpcomingManageableCompetitions = userToken => {
-  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const oneMonthAgo = new Date(Date.now() - 28 * 24 * 60 * 60 * 1000);
   const params = new URLSearchParams({
     managed_by_me: true,
-    start: oneWeekAgo.toISOString(),
+    start: oneMonthAgo.toISOString(),
   });
   return wcaApiFetch(userToken, `/competitions?${params.toString()}`);
 };


### PR DESCRIPTION
One week is a bit tight time limit for posting results. This loads competitions from the past month, let me know if you're prefer a different number of weeks =)